### PR TITLE
Examples compilation and crash fixes.

### DIFF
--- a/examples/build.sh
+++ b/examples/build.sh
@@ -1,7 +1,7 @@
 # The compilation for these examples should be very simple.
 # Something like in this file should work (if not exactly this).
-cc image.c -o image -O3 -I..
+cc image.c -o image -O3 -I.. -lm
 # These examples use SDL2 (https://libsdl.org/).
-cc cubes.c -o cubes -O3 -I.. `sdl2-config --cflags --libs`
-cc obj.c -o obj -O3 -I.. `sdl2-config --cflags --libs`
-cc fps.c -o fps -O3 -I.. `sdl2-config --cflags --libs`
+cc cubes.c -o cubes -O3 -I.. `sdl2-config --cflags --libs` -lm
+cc obj.c -o obj -O3 -I.. `sdl2-config --cflags --libs` -lm
+cc fps.c -o fps -O3 -I.. `sdl2-config --cflags --libs` -lm

--- a/examples/cubes.c
+++ b/examples/cubes.c
@@ -95,7 +95,7 @@ int main() {
             next_update = SDL_GetTicks() + 250;
         }
         average_fps[average_index++] = 1.0 / ((SDL_GetPerformanceCounter() - time_stamp) / freq);
-        if (average_index > samples) {
+        if (average_index >= samples) {
             average_index = 0;
             have_enough_samples = 1;
         }


### PR DESCRIPTION
Fixing a linkage failure due to the absence of lm, when compiling the examples.
Fixing a crash with cubes.c.
